### PR TITLE
Adding build and test framework based on CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(mlir-heir LANGUAGES CXX C)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include(MLIRHeir)
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+set(LIBS
+    ${dialect_libs}
+    MLIROptLib
+    )
+
+
+add_llvm_executable(heir-opt
+  tools/heir-opt.cpp
+  )
+
+target_link_libraries(heir-opt
+  PRIVATE
+    ${LIBS}
+  )
+
+add_subdirectory(tests)

--- a/cmake/MLIRHeir.cmake
+++ b/cmake/MLIRHeir.cmake
@@ -1,0 +1,35 @@
+if(POLICY CMP0068)
+  cmake_policy(SET CMP0068 NEW)
+  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+endif()
+
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
+find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+configure_lit_site_cfg(
+      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+      MAIN_CONFIG
+        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    )
+
+set (MLIR_HEIR_TEST_DEPENDS 
+      FileCheck count not
+      mlir-opt
+      mlir-cpu-runner
+      heir-opt
+    )
+
+  add_lit_testsuite(check-mlir-heir "Running the MLIR Heir regression tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS 
+      ${MLIR_HEIR_TEST_DEPENDS}
+)

--- a/tests/ctlz.mlir
+++ b/tests/ctlz.mlir
@@ -1,0 +1,12 @@
+// RUN: heir-opt %s --verify-roundtrip | FileCheck %s
+
+func.func @main(%arg0: i32) {
+  %0 = math.ctlz %arg0 : i32
+  func.return
+}
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32
+// CHECK-SAME:                       ) {
+// CHECK:           %[[VAL_1:.*]] = math.ctlz %[[VAL_0]] : i32
+// CHECK:           return
+// CHECK:         }

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -1,0 +1,54 @@
+# -*- Python -*-
+
+import os
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = "MLIR_HEIR"
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [".mlir"]
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.project_binary_dir, "tests")
+
+config.substitutions.append(("%PATH%", config.environment["PATH"]))
+config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
+config.substitutions.append(("%project_source_dir", config.project_source_dir))
+
+llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
+
+llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ["Inputs", "Examples", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.project_binary_dir, "tests")
+config.project_bin_dir = os.path.join(config.project_binary_dir, "bin")
+config.project_tools_dir = os.path.join(config.project_binary_dir, "tools")
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
+
+tool_dirs = [config.project_tools_dir, config.project_bin_dir,config.llvm_tools_dir]
+tools = [
+    "mlir-opt",
+    "mlir-cpu-runner",
+    "heir-opt"
+]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -1,0 +1,13 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.mlir_obj_dir = "@MLIR_BINARY_DIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.project_binary_dir = "@PROJECT_BINARY_DIR@"
+config.project_source_dir = "@PROJECT_SOURCE_DIR@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/tests/lit.cfg.py")

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -1,0 +1,11 @@
+#include "mlir/InitAllDialects.h"
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
+
+  return mlir::asMainReturnCode(
+      mlir::MlirOptMain(argc, argv, "HEIR Pass Driver", registry)
+      );
+}


### PR DESCRIPTION
This pull request introduces the initial the `heir-opt` tool similar to `mlir-opt` tool that serves as entry point in MLIR. We do not do anything meaningful here, rather register the inbuilt dialects passes the control to `mlir::MlirOptMain`. Some good description about this can be found at [How mlir-opt work](https://blog.sh1mar.in/post/mlir/mlir-opt)

We then add the test framework based on `llvm-lit` tool, the configurations for which can be found in `lit.cfg.py` and `lit.site.cfg.py`. A good tutorial to understand the standalone `lit` can be found [here](https://medium.com/@mshockwave/using-llvm-lit-out-of-tree-5cddada85a78)

To build and test the shell tutorial, you need to build the [llvm-project](https://github.com/llvm/llvm-project] as given in (Getting Started - MLIR)[https://mlir.llvm.org/getting_started/]. Assuming `llvm-project` is built in `$HOME/llvm-project-main`:

```
git clone https://github.com/makarkul/mlir-heir.git -b develop && cd mlir-heir
mkdir -p build && cd build

export LLVM_BUILD_DIR=$HOME/llvm-project-main/build

cmake -G Ninja .. -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm -DMLIR_DIR=$LLVM_BUILD_DIR/lib/cmake/mlir
cmake --build . --target check-mlir-heir
```
The only test we use is to send the `ctlz.mlir` through the tool and check it's output to be the same